### PR TITLE
Bug fixes

### DIFF
--- a/MiniCopterOptions.cs
+++ b/MiniCopterOptions.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace Oxide.Plugins
 {
-    [Info("Mini-Copter Options", "Pho3niX90", "2.1.1")]
+    [Info("Mini-Copter Options", "Pho3niX90", "2.1.2")]
     [Description("Provide a number of additional options for Mini-Copters, including storage and seats.")]
     class MiniCopterOptions : RustPlugin
     {

--- a/MiniCopterOptions.cs
+++ b/MiniCopterOptions.cs
@@ -12,6 +12,7 @@ namespace Oxide.Plugins
         bool lastRanAtNight;
         #region Prefab Modifications
 
+        private readonly string minicopterPrefab = "assets/content/vehicles/minicopter/minicopter.entity.prefab";
         private readonly string storagePrefab = "assets/prefabs/deployable/hot air balloon/subents/hab_storage.prefab";
         private readonly string storageLargePrefab = "assets/content/vehicles/boats/rhib/subents/rhib_storage.prefab";
         private readonly string autoturretPrefab = "assets/prefabs/npc/autoturret/autoturret_deployed.prefab";
@@ -430,14 +431,10 @@ namespace Oxide.Plugins
             }
         }
 
-        void StoreMiniCopterDefaults(MiniCopter copter) {
-            if (copterDefaults != null)
+        void StoreMiniCopterDefaults() {
+            var copter = GameManager.server.FindPrefab(minicopterPrefab)?.GetComponent<MiniCopter>();
+            if (copter == null)
                 return;
-
-            if (copter.liftFraction == 0 || copter.torqueScale.x == 0 || copter.torqueScale.y == 0 || copter.torqueScale.z == 0) {
-                copter.liftFraction = 0.25f;
-                copter.torqueScale = new Vector3(400f, 400f, 200f);
-            }
 
             //Puts($"Defaults for copters saved as \nfuelPerSecond = {copter.fuelPerSec}\nliftFraction = {copter.liftFraction}\ntorqueScale = {copter.torqueScale}");
             copterDefaults = new MiniCopterDefaults {
@@ -452,7 +449,7 @@ namespace Oxide.Plugins
         #region Hooks
 
         void OnServerInitialized(bool init) {
-            PrintWarning("Applying settings except storage modifications to existing MiniCopters.");
+            StoreMiniCopterDefaults();
 
             if (config.lightTail) {
                 SetupTimeHooks();
@@ -485,8 +482,6 @@ namespace Oxide.Plugins
         void OnEntitySpawned(MiniCopter copter) {
             if (copter is ScrapTransportHelicopter)
                 return;
-
-            StoreMiniCopterDefaults(copter);
 
             // Only add storage on spawn so we don't stack or mess with
             // existing player storage containers.

--- a/MiniCopterOptions.cs
+++ b/MiniCopterOptions.cs
@@ -564,6 +564,9 @@ namespace Oxide.Plugins
             if (mini == null)
                 return null;
 
+            if (!mini.IsDriver(player))
+                return null;
+
             foreach (var child in mini.children) {
                 var sphere = child as SphereEntity;
                 if ((object)sphere == null)

--- a/MiniCopterOptions.cs
+++ b/MiniCopterOptions.cs
@@ -473,9 +473,6 @@ namespace Oxide.Plugins
                 foreach (var copter in BaseNetworkable.serverEntities.OfType<MiniCopter>()) {
                     if (config.restoreDefaults)
                         RestoreMiniCopter(copter, config.reloadStorage);
-
-                    if (config.landOnCargo)
-                        UnityEngine.Object.Destroy(copter.GetComponent<MiniShipLandingGear>());
                 }
             }
         }
@@ -487,9 +484,6 @@ namespace Oxide.Plugins
             // Only add storage on spawn so we don't stack or mess with
             // existing player storage containers.
             ModifyMiniCopter(copter);
-
-            if (config.landOnCargo)
-                copter.gameObject.AddComponent<MiniShipLandingGear>();
         }
 
         void OnEntityKill(BaseNetworkable entity) {
@@ -648,7 +642,6 @@ namespace Oxide.Plugins
             public int largeStorageSize = 42;
             public int flyHackPause = 1;
             public bool autoturret = false;
-            public bool landOnCargo = true;
             public bool autoturretBattery = true;
             public bool addSearchLight = true;
             public float turretRange = 30f;
@@ -675,7 +668,6 @@ namespace Oxide.Plugins
                 GetConfig(ref flyHackPause, "Seconds to pause flyhack when dismount from heli.");
                 GetConfig(ref autoturret, "Add auto turret to heli");
                 GetConfig(ref autoturretBattery, "Auto turret uses battery");
-                GetConfig(ref landOnCargo, "Allow Minis to Land on Cargo");
                 GetConfig(ref turretRange, "Mini Turret Range (Default 30)");
                 GetConfig(ref addSearchLight, "Light: Add Searchlight to heli");
                 GetConfig(ref lightTail, "Light: Add Nightitme Tail Light");
@@ -756,39 +748,6 @@ namespace Oxide.Plugins
                 foreach (var s in sl.GetComponentsInChildren<Component>()) {
                     Puts($"-C- {s.GetType().Name} | {s.name}");
                 }
-            }
-        }
-
-        #endregion
-
-        #region Classes
-
-        public class MiniShipLandingGear : MonoBehaviour
-        {
-            private MiniCopter miniCopter;
-            private bool pCargo;
-
-            void Awake() {
-                miniCopter = GetComponent<MiniCopter>();
-            }
-
-            void OnTriggerEnter(Collider collider) {
-                if (!collider.isTrigger || !(collider.ToBaseEntity() is CargoShip) || pCargo)
-                    return;
-
-                ParentTo(miniCopter, collider.ToBaseEntity());
-            }
-
-            void OnTriggerExit(Collider collider) {
-                if (!collider.isTrigger || !(collider.ToBaseEntity() is CargoShip) || !pCargo)
-                    return;
-
-                ParentTo(miniCopter, null);
-            }
-
-            void ParentTo(MiniCopter mini, BaseEntity parent) {
-                mini.SetParent(parent, true);
-                pCargo ^= true;
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Allows for the configuration of additional Mini-Copter options, including the addition of storage containers to the Mini-Copter. 
- 
+Allows for the configuration of additional Mini-Copter options, including the addition of storage containers to the Mini-Copter.
+
 If you like the plugin, don't forget to donate for further development, and to keep it free.  [Donate here](http://https://umod.org/user/78yVj2xyGj/donate)
 
 * Increase the **Lift Fraction** to increase the take off speed.
@@ -8,7 +8,7 @@ If you like the plugin, don't forget to donate for further development, and to k
 
 Set **Restore Defaults** to true to restore the default movement and fuel consumption values on plugin unload.   Storage Containers will remain unless **Reload Storage** is set to true. **Warning:** Unloading or reloading the plugin with **Reload Storage** set to **true** will destroy any player items contained in the Mini-Copter storage stashes.
 
-**Warning about high *Lift Fraction* values:** Setting a high lift fraction can increase the risk of FlyHack kicks when a player has crashed the Mini-Copter. **Seconds to pause flyhack when dismount from heli.:** should solve the issue. 
+**Warning about high *Lift Fraction* values:** Setting a high lift fraction can increase the risk of FlyHack kicks when a player has crashed the Mini-Copter. **Seconds to pause flyhack when dismount from heli.:** should solve the issue.
 
 ## Key binds
 * The pilot can turn the search light on and off with **USE** key
@@ -20,8 +20,6 @@ The default configuration mimics the default Rust values.
 ```json
 {
   "Add auto turret to heli": false,
-  "Allow minicopter push": true,
-  "Allow Minis to Land on Cargo": true,
   "Auto turret uses battery": true,
   "Drop Storage Loot On Death": true,
   "Fuel per Second": 0.25,


### PR DESCRIPTION
- Fixed issue where unloading the plugin would set existing Scrap Transport Helicopters to MiniCopter settings, causing them to be almost impossible to steer
- The auto turret will no longer target players or some NPCs in safe zones
- Passengers of the minicopter can no longer toggle the search light on/off, only the pilot can
- Removed Land On Cargo feature since it's now a built-in Rust feature